### PR TITLE
Add quarter sizing steps and enhance corner resizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Windows can be moved to a number of predefined regions of the screen:
 - _Move to the upper right_ &#8212; &#8963;&#8984;&#8594;
 - _Move to the lower right_ &#8212; &#8963;&#8679;&#8984;&#8594;
 
-Windows may also be resized between thirds using any of the shortcuts above. For example, to have a window resized between 1/3 and 2/3 of the left region of the screen simply activate the *left half* &#8997;&#8984;&#8592; keyboard shortcut more than once. Each time the shortcut is activated Spectacle will move the window between 1/3, 2/3, and back to 1/2 of the left side of the screen. This feature also applies to the upper left, lower left, upper right, and lower right shortcuts.
+Windows may also be resized between thirds and quarters using any of the shortcuts above. For example, to have a window resized among 1/3, 2/3, 1/4, and 3/4 of the left region of the screen simply activate the *left half* &#8997;&#8984;&#8592; keyboard shortcut more than once. Each time the shortcut is activated Spectacle will cycle the window between 1/3, 2/3, 1/4, 3/4, and back to 1/2 of the left side of the screen. This feature also applies to the upper left, lower left, upper right, and lower right shortcuts.
 
 Spectacle can also move windows between horizontal and vertical thirds of the screen. The &#8963;&#8997;&#8594; keyboard shortcut will move a window to the next third of the screen, starting with the horizontal third region on the left of the screen. &#8963;&#8997;&#8592; will move a window to the previous third of the screen.
 

--- a/Spectacle/Resources/Window Position Calculations/SpectacleBottomHalfWindowCalculation.js
+++ b/Spectacle/Resources/Window Position Calculations/SpectacleBottomHalfWindowCalculation.js
@@ -4,13 +4,27 @@ windowPositionCalculationRegistry.registerWindowPositionCalculationWithAction(fu
     if (Math.abs(CGRectGetMidX(windowRect) - CGRectGetMidX(oneHalfRect)) <= 1.0) {
         var twoThirdsRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
         twoThirdsRect.height = Math.floor(visibleFrameOfDestinationScreen.height * 2 / 3.0);
+        var oneThirdRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
+        oneThirdRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 3.0);
+        var threeQuarterRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
+        threeQuarterRect.height = Math.floor(visibleFrameOfDestinationScreen.height * 3 / 4.0);
+        var oneQuarterRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
+        oneQuarterRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 4.0);
+
         if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneHalfRect, windowRect)) {
             return twoThirdsRect;
         }
         if (SpectacleCalculationHelpers.rectCenteredWithinRect(twoThirdsRect, windowRect)) {
-            var oneThirdRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
-            oneThirdRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 3.0);
             return oneThirdRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneThirdRect, windowRect)) {
+            return threeQuarterRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(threeQuarterRect, windowRect)) {
+            return oneQuarterRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneQuarterRect, windowRect)) {
+            return oneHalfRect;
         }
     }
     return oneHalfRect;

--- a/Spectacle/Resources/Window Position Calculations/SpectacleLeftHalfWindowCalculation.js
+++ b/Spectacle/Resources/Window Position Calculations/SpectacleLeftHalfWindowCalculation.js
@@ -4,13 +4,27 @@ windowPositionCalculationRegistry.registerWindowPositionCalculationWithAction(fu
     if (Math.abs(CGRectGetMidY(windowRect) - CGRectGetMidY(oneHalfRect)) <= 1.0) {
         var twoThirdRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
         twoThirdRect.width = Math.floor(visibleFrameOfDestinationScreen.width * 2 / 3.0);
+        var oneThirdRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
+        oneThirdRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 3.0);
+        var threeQuarterRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
+        threeQuarterRect.width = Math.floor(visibleFrameOfDestinationScreen.width * 3 / 4.0);
+        var oneQuarterRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
+        oneQuarterRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 4.0);
+
         if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneHalfRect, windowRect)) {
             return twoThirdRect;
         }
         if (SpectacleCalculationHelpers.rectCenteredWithinRect(twoThirdRect, windowRect)) {
-            var oneThirdsRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
-            oneThirdsRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 3.0);
-            return oneThirdsRect;
+            return oneThirdRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneThirdRect, windowRect)) {
+            return threeQuarterRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(threeQuarterRect, windowRect)) {
+            return oneQuarterRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneQuarterRect, windowRect)) {
+            return oneHalfRect;
         }
     }
     return oneHalfRect;

--- a/Spectacle/Resources/Window Position Calculations/SpectacleLowerLeftWindowCalculation.js
+++ b/Spectacle/Resources/Window Position Calculations/SpectacleLowerLeftWindowCalculation.js
@@ -2,16 +2,34 @@ windowPositionCalculationRegistry.registerWindowPositionCalculationWithAction(fu
     var oneQuarterRect = SpectacleCalculationHelpers.copyRect(visibleFrameOfDestinationScreen);
     oneQuarterRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 2.0);
     oneQuarterRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 2.0);
-    if (Math.abs(CGRectGetMidY(windowRect) - CGRectGetMidY(oneQuarterRect)) <= 1.0) {
+    if (Math.abs(CGRectGetMidY(windowRect) - CGRectGetMidY(oneQuarterRect)) <= 1.0 && Math.abs(CGRectGetMidX(windowRect) - CGRectGetMidX(oneQuarterRect)) <= 1.0) {
         var twoThirdRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
         twoThirdRect.width = Math.floor(visibleFrameOfDestinationScreen.width * 2 / 3.0);
+        twoThirdRect.height = Math.floor(visibleFrameOfDestinationScreen.height * 2 / 3.0);
+        var oneThirdRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
+        oneThirdRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 3.0);
+        oneThirdRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 3.0);
+        var threeQuarterRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
+        threeQuarterRect.width = Math.floor(visibleFrameOfDestinationScreen.width * 3 / 4.0);
+        threeQuarterRect.height = Math.floor(visibleFrameOfDestinationScreen.height * 3 / 4.0);
+        var oneQuarterSmallRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
+        oneQuarterSmallRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 4.0);
+        oneQuarterSmallRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 4.0);
+
         if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneQuarterRect, windowRect)) {
             return twoThirdRect;
         }
         if (SpectacleCalculationHelpers.rectCenteredWithinRect(twoThirdRect, windowRect)) {
-            var oneThirdsRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
-            oneThirdsRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 3.0);
-            return oneThirdsRect;
+            return oneThirdRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneThirdRect, windowRect)) {
+            return threeQuarterRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(threeQuarterRect, windowRect)) {
+            return oneQuarterSmallRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneQuarterSmallRect, windowRect)) {
+            return oneQuarterRect;
         }
     }
     return oneQuarterRect;

--- a/Spectacle/Resources/Window Position Calculations/SpectacleLowerRightWindowCalculation.js
+++ b/Spectacle/Resources/Window Position Calculations/SpectacleLowerRightWindowCalculation.js
@@ -3,18 +3,38 @@ windowPositionCalculationRegistry.registerWindowPositionCalculationWithAction(fu
     oneQuarterRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 2.0);
     oneQuarterRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 2.0);
     oneQuarterRect.x += oneQuarterRect.width;
-    if (Math.abs(CGRectGetMidY(windowRect) - CGRectGetMidY(oneQuarterRect)) <= 1.0) {
+    if (Math.abs(CGRectGetMidY(windowRect) - CGRectGetMidY(oneQuarterRect)) <= 1.0 && Math.abs(CGRectGetMidX(windowRect) - CGRectGetMidX(oneQuarterRect)) <= 1.0) {
         var twoThirdRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
         twoThirdRect.width = Math.floor(visibleFrameOfDestinationScreen.width * 2 / 3.0);
+        twoThirdRect.height = Math.floor(visibleFrameOfDestinationScreen.height * 2 / 3.0);
         twoThirdRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - twoThirdRect.width;
+        var oneThirdRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
+        oneThirdRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 3.0);
+        oneThirdRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 3.0);
+        oneThirdRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - oneThirdRect.width;
+        var threeQuarterRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
+        threeQuarterRect.width = Math.floor(visibleFrameOfDestinationScreen.width * 3 / 4.0);
+        threeQuarterRect.height = Math.floor(visibleFrameOfDestinationScreen.height * 3 / 4.0);
+        threeQuarterRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - threeQuarterRect.width;
+        var oneQuarterSmallRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
+        oneQuarterSmallRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 4.0);
+        oneQuarterSmallRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 4.0);
+        oneQuarterSmallRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - oneQuarterSmallRect.width;
+
         if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneQuarterRect, windowRect)) {
             return twoThirdRect;
         }
         if (SpectacleCalculationHelpers.rectCenteredWithinRect(twoThirdRect, windowRect)) {
-            var oneThirdsRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
-            oneThirdsRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 3.0);
-            oneThirdsRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - oneThirdsRect.width;
-            return oneThirdsRect;
+            return oneThirdRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneThirdRect, windowRect)) {
+            return threeQuarterRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(threeQuarterRect, windowRect)) {
+            return oneQuarterSmallRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneQuarterSmallRect, windowRect)) {
+            return oneQuarterRect;
         }
     }
     return oneQuarterRect;

--- a/Spectacle/Resources/Window Position Calculations/SpectacleRightHalfWindowCalculation.js
+++ b/Spectacle/Resources/Window Position Calculations/SpectacleRightHalfWindowCalculation.js
@@ -6,14 +6,30 @@ windowPositionCalculationRegistry.registerWindowPositionCalculationWithAction(fu
         var twoThirdRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
         twoThirdRect.width = Math.floor(visibleFrameOfDestinationScreen.width * 2 / 3.0);
         twoThirdRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - twoThirdRect.width;
+        var oneThirdRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
+        oneThirdRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 3.0);
+        oneThirdRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - oneThirdRect.width;
+        var threeQuarterRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
+        threeQuarterRect.width = Math.floor(visibleFrameOfDestinationScreen.width * 3 / 4.0);
+        threeQuarterRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - threeQuarterRect.width;
+        var oneQuarterRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
+        oneQuarterRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 4.0);
+        oneQuarterRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - oneQuarterRect.width;
+
         if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneHalfRect, windowRect)) {
             return twoThirdRect;
         }
         if (SpectacleCalculationHelpers.rectCenteredWithinRect(twoThirdRect, windowRect)) {
-            var oneThirdsRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
-            oneThirdsRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 3.0);
-            oneThirdsRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - oneThirdsRect.width;
-            return oneThirdsRect;
+            return oneThirdRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneThirdRect, windowRect)) {
+            return threeQuarterRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(threeQuarterRect, windowRect)) {
+            return oneQuarterRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneQuarterRect, windowRect)) {
+            return oneHalfRect;
         }
     }
     return oneHalfRect;

--- a/Spectacle/Resources/Window Position Calculations/SpectacleTopHalfWindowCalculation.js
+++ b/Spectacle/Resources/Window Position Calculations/SpectacleTopHalfWindowCalculation.js
@@ -6,14 +6,30 @@ windowPositionCalculationRegistry.registerWindowPositionCalculationWithAction(fu
         var twoThirdsRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
         twoThirdsRect.height = Math.floor(visibleFrameOfDestinationScreen.height * 2 / 3.0);
         twoThirdsRect.y = visibleFrameOfDestinationScreen.y + visibleFrameOfDestinationScreen.height - twoThirdsRect.height;
+        var oneThirdRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
+        oneThirdRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 3.0);
+        oneThirdRect.y = visibleFrameOfDestinationScreen.y + visibleFrameOfDestinationScreen.height - oneThirdRect.height;
+        var threeQuarterRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
+        threeQuarterRect.height = Math.floor(visibleFrameOfDestinationScreen.height * 3 / 4.0);
+        threeQuarterRect.y = visibleFrameOfDestinationScreen.y + visibleFrameOfDestinationScreen.height - threeQuarterRect.height;
+        var oneQuarterRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
+        oneQuarterRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 4.0);
+        oneQuarterRect.y = visibleFrameOfDestinationScreen.y + visibleFrameOfDestinationScreen.height - oneQuarterRect.height;
+
         if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneHalfRect, windowRect)) {
             return twoThirdsRect;
         }
         if (SpectacleCalculationHelpers.rectCenteredWithinRect(twoThirdsRect, windowRect)) {
-            var oneThirdRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
-            oneThirdRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 3.0);
-            oneThirdRect.y = visibleFrameOfDestinationScreen.y + visibleFrameOfDestinationScreen.height - oneThirdRect.height;
             return oneThirdRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneThirdRect, windowRect)) {
+            return threeQuarterRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(threeQuarterRect, windowRect)) {
+            return oneQuarterRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneQuarterRect, windowRect)) {
+            return oneHalfRect;
         }
     }
     return oneHalfRect;

--- a/Spectacle/Resources/Window Position Calculations/SpectacleUpperLeftWindowCalculation.js
+++ b/Spectacle/Resources/Window Position Calculations/SpectacleUpperLeftWindowCalculation.js
@@ -3,16 +3,38 @@ windowPositionCalculationRegistry.registerWindowPositionCalculationWithAction(fu
     oneQuarterRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 2.0);
     oneQuarterRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 2.0);
     oneQuarterRect.y = visibleFrameOfDestinationScreen.y + Math.floor(visibleFrameOfDestinationScreen.height / 2.0) + (visibleFrameOfDestinationScreen.height % 2.0);
-    if (Math.abs(CGRectGetMidY(windowRect) - CGRectGetMidY(oneQuarterRect)) <= 1.0) {
+    if (Math.abs(CGRectGetMidY(windowRect) - CGRectGetMidY(oneQuarterRect)) <= 1.0 && Math.abs(CGRectGetMidX(windowRect) - CGRectGetMidX(oneQuarterRect)) <= 1.0) {
         var twoThirdRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
         twoThirdRect.width = Math.floor(visibleFrameOfDestinationScreen.width * 2 / 3.0);
+        twoThirdRect.height = Math.floor(visibleFrameOfDestinationScreen.height * 2 / 3.0);
+        twoThirdRect.y = visibleFrameOfDestinationScreen.y + visibleFrameOfDestinationScreen.height - twoThirdRect.height;
+        var oneThirdRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
+        oneThirdRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 3.0);
+        oneThirdRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 3.0);
+        oneThirdRect.y = visibleFrameOfDestinationScreen.y + visibleFrameOfDestinationScreen.height - oneThirdRect.height;
+        var threeQuarterRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
+        threeQuarterRect.width = Math.floor(visibleFrameOfDestinationScreen.width * 3 / 4.0);
+        threeQuarterRect.height = Math.floor(visibleFrameOfDestinationScreen.height * 3 / 4.0);
+        threeQuarterRect.y = visibleFrameOfDestinationScreen.y + visibleFrameOfDestinationScreen.height - threeQuarterRect.height;
+        var oneQuarterSmallRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
+        oneQuarterSmallRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 4.0);
+        oneQuarterSmallRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 4.0);
+        oneQuarterSmallRect.y = visibleFrameOfDestinationScreen.y + visibleFrameOfDestinationScreen.height - oneQuarterSmallRect.height;
+
         if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneQuarterRect, windowRect)) {
             return twoThirdRect;
         }
         if (SpectacleCalculationHelpers.rectCenteredWithinRect(twoThirdRect, windowRect)) {
-            var oneThirdsRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
-            oneThirdsRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 3.0);
-            return oneThirdsRect;
+            return oneThirdRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneThirdRect, windowRect)) {
+            return threeQuarterRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(threeQuarterRect, windowRect)) {
+            return oneQuarterSmallRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneQuarterSmallRect, windowRect)) {
+            return oneQuarterRect;
         }
     }
     return oneQuarterRect;

--- a/Spectacle/Resources/Window Position Calculations/SpectacleUpperRightWindowCalculation.js
+++ b/Spectacle/Resources/Window Position Calculations/SpectacleUpperRightWindowCalculation.js
@@ -4,18 +4,42 @@ windowPositionCalculationRegistry.registerWindowPositionCalculationWithAction(fu
     oneQuarterRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 2.0);
     oneQuarterRect.x += oneQuarterRect.width;
     oneQuarterRect.y = visibleFrameOfDestinationScreen.y + Math.floor(visibleFrameOfDestinationScreen.height / 2.0) + (visibleFrameOfDestinationScreen.height % 2.0);
-    if (Math.abs(CGRectGetMidY(windowRect) - CGRectGetMidY(oneQuarterRect)) <= 1.0) {
+    if (Math.abs(CGRectGetMidY(windowRect) - CGRectGetMidY(oneQuarterRect)) <= 1.0 && Math.abs(CGRectGetMidX(windowRect) - CGRectGetMidX(oneQuarterRect)) <= 1.0) {
         var twoThirdRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
         twoThirdRect.width = Math.floor(visibleFrameOfDestinationScreen.width * 2 / 3.0);
+        twoThirdRect.height = Math.floor(visibleFrameOfDestinationScreen.height * 2 / 3.0);
         twoThirdRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - twoThirdRect.width;
+        twoThirdRect.y = visibleFrameOfDestinationScreen.y + visibleFrameOfDestinationScreen.height - twoThirdRect.height;
+        var oneThirdRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
+        oneThirdRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 3.0);
+        oneThirdRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 3.0);
+        oneThirdRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - oneThirdRect.width;
+        oneThirdRect.y = visibleFrameOfDestinationScreen.y + visibleFrameOfDestinationScreen.height - oneThirdRect.height;
+        var threeQuarterRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
+        threeQuarterRect.width = Math.floor(visibleFrameOfDestinationScreen.width * 3 / 4.0);
+        threeQuarterRect.height = Math.floor(visibleFrameOfDestinationScreen.height * 3 / 4.0);
+        threeQuarterRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - threeQuarterRect.width;
+        threeQuarterRect.y = visibleFrameOfDestinationScreen.y + visibleFrameOfDestinationScreen.height - threeQuarterRect.height;
+        var oneQuarterSmallRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
+        oneQuarterSmallRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 4.0);
+        oneQuarterSmallRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 4.0);
+        oneQuarterSmallRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - oneQuarterSmallRect.width;
+        oneQuarterSmallRect.y = visibleFrameOfDestinationScreen.y + visibleFrameOfDestinationScreen.height - oneQuarterSmallRect.height;
+
         if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneQuarterRect, windowRect)) {
             return twoThirdRect;
         }
         if (SpectacleCalculationHelpers.rectCenteredWithinRect(twoThirdRect, windowRect)) {
-            var oneThirdsRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
-            oneThirdsRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 3.0);
-            oneThirdsRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - oneThirdsRect.width;
-            return oneThirdsRect;
+            return oneThirdRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneThirdRect, windowRect)) {
+            return threeQuarterRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(threeQuarterRect, windowRect)) {
+            return oneQuarterSmallRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneQuarterSmallRect, windowRect)) {
+            return oneQuarterRect;
         }
     }
     return oneQuarterRect;


### PR DESCRIPTION
## Summary
- support quarter and three-quarter steps when resizing windows
- update corner calculations to resize height along with width
- document quarter-based resizing in README

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846123f8fdc832bb36c8c83413788e6